### PR TITLE
Fix issue when reading locale in old HA versions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -91,7 +91,7 @@ class SunCard extends LitElement {
 
   processLastHass () {
     this.config.darkMode = this.config.darkMode ?? this.lastHass.themes.darkMode
-    this.config.language = this.config.language ?? this.lastHass.locale.language
+    this.config.language = this.config.language ?? this.lastHass.locale?.language ?? this.lastHass.language
 
     const times = {
       dawn: this.parseTime(this.lastHass.states['sun.sun'].attributes.next_dawn),

--- a/src/types/custom/custom-card-helpers.d.ts
+++ b/src/types/custom/custom-card-helpers.d.ts
@@ -1,6 +1,7 @@
 declare module 'custom-card-helpers' {
   export interface HomeAssistant {
     themes: Themes & { darkMode: boolean }
+    language: string,
     locale: { language: string }
     states: {
       'sun.sun': {


### PR DESCRIPTION
Some old Home assistant versions doesn't provide the `locale` property, this causes the card to crash by trying to access properties inside `locale` when it's `undefined`