### PR TITLE
Added Chinese and Japanese

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Note: If you get an error similar to this `Custom element doesn't exist` you wil
 | timeFormat    | `'12h'`/`'24h'`      | Displayed time format                | Locale based on Home assistant language             |
 | title         | `string`             | Card title                           | Doesn't display a title by default                  |         |
 
-(<sup>1</sup>) Supported languages: `da`, `de`, `en`, `es`, `et`, `fi`, `fr`, `hu`, `it`, `nl`, `pl`, `pt-BR`, `ru`, `sl`, `sv`, `zh-Hans`, `zh-Hant`
+(<sup>1</sup>) Supported languages: `da`, `de`, `en`, `es`, `et`, `fi`, `fr`, `hu`, `it`, `ja`, `nl`, `pl`, `pt-BR`, `ru`, `sl`, `sv`, `zh-Hans`, `zh-Hant`
 
 ## Known issues
 - Home assistant seems to provide next events instead today's one 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Note: If you get an error similar to this `Custom element doesn't exist` you wil
 | timeFormat    | `'12h'`/`'24h'`      | Displayed time format                | Locale based on Home assistant language             |
 | title         | `string`             | Card title                           | Doesn't display a title by default                  |         |
 
-(<sup>1</sup>) Supported languages: `da`, `de`, `en`, `es`, `et`, `fi`, `fr`, `hu`, `it`, `nl`, `pl`, `pt-BR`, `ru`, `sl`, `sv`
+(<sup>1</sup>) Supported languages: `da`, `de`, `en`, `es`, `et`, `fi`, `fr`, `hu`, `it`, `nl`, `pl`, `pt-BR`, `ru`, `sl`, `sv`, `zh-Hans`, `zh-Hant`
 
 ## Known issues
 - Home assistant seems to provide next events instead today's one 

--- a/src/assets/localization/languages/ja.json
+++ b/src/assets/localization/languages/ja.json
@@ -3,7 +3,7 @@
   "Dawn": "明け方",
   "Dusk": "夕",
   "Elevation": "仰俯角",
-  "Noon": "日中",
+  "Noon": "太陽の正午",
   "Sunrise": "日出",
   "Sunset": "日沒",
   "errors": {

--- a/src/assets/localization/languages/ja.json
+++ b/src/assets/localization/languages/ja.json
@@ -1,0 +1,12 @@
+{
+  "Azimuth": "方位角",
+  "Dawn": "明け方",
+  "Dusk": "夕",
+  "Elevation": "仰俯角",
+  "Noon": "日中",
+  "Sunrise": "日出",
+  "Sunset": "日沒",
+  "errors": {
+    "SunIntegrationNotFound": "インテグレーション Sun は検索できません"
+  }
+}

--- a/src/assets/localization/languages/zh-Hans.json
+++ b/src/assets/localization/languages/zh-Hans.json
@@ -1,12 +1,12 @@
 {
-    "Azimuth": "方位角",
-    "Dawn": "拂晓",
-    "Dusk": "傍晚",
-    "Elevation": "仰角",
-    "Noon": "日中",
-    "Sunrise": "日出",
-    "Sunset": "日落",
-    "errors": {
-        "SunIntegrationNotFound": "未搜索到集成 Sun"
-    }
+  "Azimuth": "方位角",
+  "Dawn": "拂晓",
+  "Dusk": "傍晚",
+  "Elevation": "仰角",
+  "Noon": "日中",
+  "Sunrise": "日出",
+  "Sunset": "日落",
+  "errors": {
+    "SunIntegrationNotFound": "未搜索到集成 Sun"
+  }
 }

--- a/src/assets/localization/languages/zh-Hans.json
+++ b/src/assets/localization/languages/zh-Hans.json
@@ -1,0 +1,12 @@
+{
+    "Azimuth": "方位角",
+    "Dawn": "拂晓",
+    "Dusk": "傍晚",
+    "Elevation": "仰角",
+    "Noon": "日中",
+    "Sunrise": "日出",
+    "Sunset": "日落",
+    "errors": {
+        "SunIntegrationNotFound": "未搜索到集成 Sun"
+    }
+}

--- a/src/assets/localization/languages/zh-Hant.json
+++ b/src/assets/localization/languages/zh-Hant.json
@@ -1,12 +1,12 @@
 {
-    "Azimuth": "方位",
-    "Dawn": "黎明",
-    "Dusk": "黃昏",
-    "Elevation": "仰角",
-    "Noon": "日正當中",
-    "Sunrise": "日昇",
-    "Sunset": "日落",
-    "errors": {
-        "SunIntegrationNotFound": "沒有找到整合 Sun"
-    }
+  "Azimuth": "方位",
+  "Dawn": "黎明",
+  "Dusk": "黃昏",
+  "Elevation": "仰角",
+  "Noon": "日正當中",
+  "Sunrise": "日昇",
+  "Sunset": "日落",
+  "errors": {
+    "SunIntegrationNotFound": "沒有找到整合 Sun"
+  }
 }

--- a/src/assets/localization/languages/zh-Hant.json
+++ b/src/assets/localization/languages/zh-Hant.json
@@ -1,0 +1,12 @@
+{
+    "Azimuth": "方位",
+    "Dawn": "黎明",
+    "Dusk": "黃昏",
+    "Elevation": "仰角",
+    "Noon": "日正當中",
+    "Sunrise": "日昇",
+    "Sunset": "日落",
+    "errors": {
+        "SunIntegrationNotFound": "沒有找到整合 Sun"
+    }
+}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -35,7 +35,7 @@ export class Constants {
 
   static readonly HORIZON_Y = 108
   static readonly LOCALIZATION_LANGUAGES: Record<string, TSunCardTexts> = {
-    da, de, en, es, et, fi, fr, hu, it, nl, pl, 'pt-BR': ptBR, ru, sl, sv, 'zh-Hans': zh_Hans, 'zh_Hant': zh_Hant
+    da, de, en, es, et, fi, fr, hu, it, nl, pl, 'pt-BR': ptBR, ru, sl, sv, 'zh-Hans': zh_Hans, 'zh-Hant': zh_Hant
   }
   static readonly SUN_RADIUS = 17
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -13,6 +13,8 @@ import ptBR from './assets/localization/languages/pt-BR.json'
 import ru from './assets/localization/languages/ru.json'
 import sl from './assets/localization/languages/sl.json'
 import sv from './assets/localization/languages/sv.json'
+import zh_Hans from './assets/localization/languages/zh-Hans.json'
+import zh_Hant from './assets/localization/languages/zh-Hant.json'
 import { TSunCardConfig, TSunCardTexts } from './types'
 
 export class Constants {
@@ -33,7 +35,7 @@ export class Constants {
 
   static readonly HORIZON_Y = 108
   static readonly LOCALIZATION_LANGUAGES: Record<string, TSunCardTexts> = {
-    da, de, en, es, et, fi, fr, hu, it, nl, pl, 'pt-BR': ptBR, ru, sl, sv
+    da, de, en, es, et, fi, fr, hu, it, nl, pl, 'pt-BR': ptBR, ru, sl, sv, 'zh-Hans': zh_Hans, 'zh_Hant': zh_Hant
   }
   static readonly SUN_RADIUS = 17
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -7,6 +7,7 @@ import fi from './assets/localization/languages/fi.json'
 import fr from './assets/localization/languages/fr.json'
 import hu from './assets/localization/languages/hu.json'
 import it from './assets/localization/languages/it.json'
+import ja from './assets/localization/languages/ja.json'
 import nl from './assets/localization/languages/nl.json'
 import pl from './assets/localization/languages/pl.json'
 import ptBR from './assets/localization/languages/pt-BR.json'
@@ -35,7 +36,7 @@ export class Constants {
 
   static readonly HORIZON_Y = 108
   static readonly LOCALIZATION_LANGUAGES: Record<string, TSunCardTexts> = {
-    da, de, en, es, et, fi, fr, hu, it, nl, pl, 'pt-BR': ptBR, ru, sl, sv, 'zh-Hans': zh_Hans, 'zh_Hant': zh_Hant
+    da, de, en, es, et, fi, fr, hu, it, nl, pl, 'pt-BR': ptBR, ru, sl, sv, 'zh-Hans': zh_Hans, 'zh-Hant': zh_Hant, ja
   }
   static readonly SUN_RADIUS = 17
 }


### PR DESCRIPTION
Elevation should be translated as "仰角" instead of "海拔": #131 
Traditional Chinese By: #94 
Naming convention used: [BCP 47](https://tools.ietf.org/html/bcp47)
Language and Readme have been updated
