### PR TITLE
Fix the sun position calculations

### DIFF
--- a/src/utils/HelperFunctions.ts
+++ b/src/utils/HelperFunctions.ts
@@ -30,8 +30,8 @@ export class HelperFunctions {
     return Object.keys(Constants.LOCALIZATION_LANGUAGES).includes(language)
   }
 
-  public static todayAtStartOfDay (): Date {
-    const today = new Date()
+  public static todayAtStartOfDay (now: Date): Date {
+    const today = new Date(now)
     today.setHours(0)
     today.setMinutes(0)
     today.setSeconds(0)
@@ -40,8 +40,8 @@ export class HelperFunctions {
     return today
   }
 
-  public static todayAtEndOfDay (): Date {
-    const today = new Date()
+  public static todayAtEndOfDay (now: Date): Date {
+    const today = new Date(now)
     today.setHours(23)
     today.setMinutes(59)
     today.setSeconds(59)

--- a/tests/unit/components/sunCard/SunCard.spec.ts
+++ b/tests/unit/components/sunCard/SunCard.spec.ts
@@ -377,7 +377,7 @@ describe('SunCard', () => {
         next_dusk: 0,
         next_noon: 0,
         next_rising: 0
-      })
+      }, new Date(0))
 
       expect(result).toEqual({
         dawn: new Date(0),
@@ -387,14 +387,14 @@ describe('SunCard', () => {
         sunset: new Date(0)
       })
 
-      expect(readTimeSpy).toHaveBeenCalledTimes(4)
+      expect(readTimeSpy).toHaveBeenCalledTimes(5)
     })
   })
 
   describe('readTime', () => {
     it('sets a specific day, month and year to a provided string date', () => {
       const result = sunCard['readTime']('0', 2021, 5, 12)
-      expect(result).toEqual(new Date(1623456000000)) // Sat Jun 12 2021 01:00:00 GMT+0100 (British Summer Time)
+      expect(result).toEqual(new Date(2021, 5, 12, 0, 0, 0))
     })
   })
 
@@ -403,7 +403,7 @@ describe('SunCard', () => {
       const path = new SVGPathElement()
       jest.spyOn((sunCard as any).shadowRoot, 'querySelector').mockReturnValue(path)
 
-      const result = sunCard['calculateSunInfo'](new Date(0), new Date(0))
+      const result = sunCard['calculateSunInfo'](new Date(0), new Date(0), new Date(0))
       expect(result).toEqual({
         dawnProgressPercent: 0,
         dayProgressPercent: 0,

--- a/tests/unit/utils/HelperFunctions.spec.ts
+++ b/tests/unit/utils/HelperFunctions.spec.ts
@@ -83,7 +83,7 @@ describe('HelperFunctions', () => {
 
   describe('todayAtStartOfDay', () => {
     it('returns today at the beginning of the day', () => {
-      const result = HelperFunctions.todayAtStartOfDay()
+      const result = HelperFunctions.todayAtStartOfDay(new Date(0))
       expect(result.getHours()).toBe(0)
       expect(result.getMinutes()).toBe(0)
       expect(result.getSeconds()).toBe(0)
@@ -93,7 +93,7 @@ describe('HelperFunctions', () => {
 
   describe('todayAtEndOfDay', () => {
     it('returns today at the end of the day', () => {
-      const result = HelperFunctions.todayAtEndOfDay()
+      const result = HelperFunctions.todayAtEndOfDay(new Date(0))
       expect(result.getHours()).toBe(23)
       expect(result.getMinutes()).toBe(59)
       expect(result.getSeconds()).toBe(59)


### PR DESCRIPTION
Fix the sun position calculations:

- Use now() as a basis for normalizing all next_xxx values from Home Assistant and locat date/time attributes insteod of UTC (since it should be from the viewpoint of the HA setup)
- Use a single source for now() so it's consistent in all the calculations
- Also fixed the readTime test as it was sensitive to the time zone of the test environment

This works well for the entire 24h span - I checked by hacking the now value to loop the entire day and "tomorrow" (i.e. simulating today past midnight).